### PR TITLE
Put get_file(), alias for get_file_path() in __init__

### DIFF
--- a/flexp/flexp/__init__.py
+++ b/flexp/flexp/__init__.py
@@ -7,6 +7,7 @@ from flexp.flexp.core import (
     backup_sources,
     get_static_file,
     get_file_path,
+    get_file,
     set_metadata,
     disable,
 )


### PR DESCRIPTION
There is an alias `get_file()` for `get_file_path()` which is shorter. It wasn't used in __init__ so it wasn't possible to use it the same way as other functions.