### PR TITLE
Flexp.close()

### DIFF
--- a/flexp/flexp/__init__.py
+++ b/flexp/flexp/__init__.py
@@ -10,4 +10,5 @@ from flexp.flexp.core import (
     get_file,
     set_metadata,
     disable,
+    close,
 )

--- a/flexp/flexp/logging.py
+++ b/flexp/flexp/logging.py
@@ -58,3 +58,4 @@ def _close_file_handlers():
     root_logger = logging.getLogger()
     for file_handler in root_logger.handlers:
         file_handler.close()
+    root_logger.handlers = []

--- a/tests/test_flexp.py
+++ b/tests/test_flexp.py
@@ -3,8 +3,12 @@
 import atexit
 import io
 import os
+import time
 from os import path
 import shutil
+from pprint import pprint
+
+import pytest
 
 from flexp import flexp
 
@@ -49,3 +53,52 @@ def test_static():
 
     os.unlink(file_path)
     os.rmdir(static_folder)
+
+
+def test_close():
+    exp_root_dir = "tests/data/"
+    expdir1 = path.join(exp_root_dir, "exp01")
+    expdir2 = path.join(exp_root_dir, "exp02")
+
+    # Remove the experiment dir if it exists
+    if os.path.exists(expdir1):
+        shutil.rmtree(expdir1)
+    if os.path.exists(expdir2):
+        shutil.rmtree(expdir2)
+
+    # We have to reset the _eh to make flexp stop complaining about calling setup twice.
+    flexp.core._eh = {}
+    flexp.setup(exp_root_dir, "exp01", with_date=False)
+    flexp.close()
+
+    assert path.isfile(os.path.join(expdir1, "flexp_info.txt")), \
+        "flexp didn't create flexp_info.txt after calling flexp.close()"
+
+    flexp.setup(exp_root_dir, "exp02", with_date=False)
+    flexp.close()
+
+    # Ensure log files doesn't contain the same rows
+    log1 = load_log_without_timestamp(os.path.join(expdir1, "log.txt"))
+    log2 = load_log_without_timestamp(os.path.join(expdir2, "log.txt"))
+    assert len(set(log1) & set(log2)) == 0, \
+        "Log files contains same rows"
+
+    # Ensure not possible to call flexp.setup() twice
+    with pytest.raises(Exception):
+        flexp.setup(exp_root_dir, "exp01", with_date=False, override_dir=True)
+        flexp.setup(exp_root_dir, "exp02", with_date=False, override_dir=True)
+
+    # Disable logging to be able to delete the experiment directory.
+    flexp.disable()
+
+    # Remove the experiment dir
+    if os.path.exists(expdir1):
+        shutil.rmtree(expdir1)
+
+    if os.path.exists(expdir2):
+        shutil.rmtree(expdir2)
+
+
+def load_log_without_timestamp(filename):
+    with open(filename) as f:
+        return [row[25:] for row in f.readlines()]


### PR DESCRIPTION
It allows  to call flexp.setup() multiple times in one script. Might be used if multiple models are trained in one script - more experiment folder is created.

Changes ensures that:
 - no exeption is raised when calling flexp.setup(), flexp.close(), flexp.setup()
 - exeption is raised when calling flexp.setup(), flexp.setup()
 - log files are correct
 - flexp_info.txt is created at the time of calling flexp.close() 

Sorry, some formating was changed when I used automatic formating.