### PR TITLE
Color failed experiments

### DIFF
--- a/flexp/browser/browser.py
+++ b/flexp/browser/browser.py
@@ -396,6 +396,8 @@ def html_navigation(base_dir, selected_experiment=None):
 
         if not path.exists(path.join(exp_dir, "flexp_info.txt")):
             classes.append("running")
+        elif not path.exists(path.join(exp_dir, ".SUCCESS")):
+            classes.append("failed")
         items.append(
             u"""<div class='' style='white-space: nowrap;'>
             <div onclick=\"$('#dialog-confirm').data('folder', '{exp_dir}').dialog('open')\" class=\"delete\">&nbsp;</div>

--- a/flexp/browser/browser.py
+++ b/flexp/browser/browser.py
@@ -396,7 +396,7 @@ def html_navigation(base_dir, selected_experiment=None):
 
         if not path.exists(path.join(exp_dir, "flexp_info.txt")):
             classes.append("running")
-        elif not path.exists(path.join(exp_dir, ".SUCCESS")):
+        elif path.exists(path.join(exp_dir, ".FAIL")):
             classes.append("failed")
         items.append(
             u"""<div class='' style='white-space: nowrap;'>

--- a/flexp/browser/static/style.css
+++ b/flexp/browser/static/style.css
@@ -149,6 +149,10 @@ div.tooltip {
     background-color: #fcc;
 }
 
+.failed {
+    background-color: #d99;
+}
+
 /* --- rc-rank file --- */
 .rc-rank-file{
     margin: 10px 10px 0 0;

--- a/flexp/flexp/core.py
+++ b/flexp/flexp/core.py
@@ -32,6 +32,7 @@ class ExperimentHandler(object):
     """Class handling experiment."""
 
     METADATA_FILE_PATH = "flexp_info.txt"
+    SUCCESS_PATH = ".SUCCESS"
 
     def __init__(self, default_rights=RWXRWS):
         self._setup = False
@@ -48,6 +49,20 @@ class ExperimentHandler(object):
 
         self.disabled = False
         self.default_rights = default_rights
+
+        # exit reason info
+        self._exit_code = None
+        self._exception = None
+        self._orig_exit = sys.exit
+        sys.exit = self._exit
+        sys.excepthook = self._exc_handler
+
+    def _exit(self, code=0):
+        self._exit_code = code
+        self._orig_exit(code)
+
+    def _exc_handler(self, exc_type, exc, *args):
+        self._exception = exc
 
     @property
     def name(self):
@@ -115,6 +130,8 @@ class ExperimentHandler(object):
         os.chmod(self.get_file_path(self.METADATA_FILE_PATH), self.default_rights)
         log.info("metadata have been saved to " + self.get_file_path(self.METADATA_FILE_PATH))
         log.info("experiment folder: {}".format(self.get_experiment_dir()))
+        if self._exit_code is None and self._exception is None:
+            open(self.get_file_path(self.SUCCESS_PATH), "w").close()
 
     def get_experiment_dir(self):
         """

--- a/flexp/flexp/core.py
+++ b/flexp/flexp/core.py
@@ -144,15 +144,10 @@ class ExperimentHandler(object):
                     print(self._exception, file=fout)
 
             if self._exception is not None:
-                try:
-                    raise self._exception
-                except Exception:
-                    log.error(
-                        "",
-                        exc_info=(
-                            self._exc_type, self._exception, self._traceback
-                        )
-                    )
+                log.error(
+                    "",
+                    exc_info=(self._exc_type, self._exception, self._traceback)
+                )
 
     def get_experiment_dir(self):
         """


### PR DESCRIPTION
This change highlights failed experiments (those that raised an exception or sys.exited) with a shade of red slightly darker than the one highlighting running experiments. Failed experiments are recognized by a .FAIL file in their experiment dir. This allows for batch cleanup from the command line. Maybe some option to filter them out of the experiment list or batch delete them from the web UI would also be useful.

This also adds logging of exception traceback (closes #26 ).