### PR TITLE
Experiments dir as a command line parameter in flexp-browser

### DIFF
--- a/flexp/browser/browser.py
+++ b/flexp/browser/browser.py
@@ -7,6 +7,7 @@ Usage:
 Options:
   -h --help     Show this screen.
 """
+
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -22,11 +23,11 @@ import traceback
 import click
 import tornado.ioloop
 import tornado.web
+from flexp.browser.utils import setup_logging
 
 from flexp.browser.html.generic import DescriptionToHtml, FilesToHtml, ImagesToHtml, FlexpInfoToHtml, CsvToHtml, \
     TxtToHtml, StringToHtml
 from flexp.browser.html.to_html import ToHtml
-from flexp.browser.utils import setup_logging
 from flexp.flow import Chain
 from flexp.utils import get_logger
 from flexp.utils import import_by_filename, PartialFormatter, exception_safe
@@ -70,7 +71,13 @@ def default_get_metrics(file_path):
     return metrics_list
 
 
-def run(port=7777, chain=default_html_chain, get_metrics_fcn=default_get_metrics, metrics_file="metrics.csv"):
+def run(
+        port=7777,
+        chain=default_html_chain,
+        get_metrics_fcn=default_get_metrics,
+        metrics_file="metrics.csv",
+        experiments_dir=os.getcwd()
+):
     """
     Run the whole browser with optional own `port` number and `chain` of ToHtml modules.
     Allows reading main metrics from all experiments and show them in experiment list.
@@ -80,6 +87,8 @@ def run(port=7777, chain=default_html_chain, get_metrics_fcn=default_get_metrics
     metrics and return dict[metric_name, value].
     :param str metrics_file: Filename in each experiment dir which contains metrics values.
     """
+    MainHandler.experiments_folder = experiments_dir
+    AjaxHandler.experiments_folder = experiments_dir
 
     # append new modules to the default chain
     if isinstance(chain, ToHtml):
@@ -99,11 +108,18 @@ def run(port=7777, chain=default_html_chain, get_metrics_fcn=default_get_metrics
     here_path = os.path.dirname(os.path.abspath(__file__))
 
     app = tornado.web.Application([
+        # (r"/", MainHandler, main_handler_params),
+        # (r'/(favicon.ico)', tornado.web.StaticFileHandler, {"path": path.join(here_path, "static/")}),
+        # (r"/file/(.*)", NoCacheStaticHandler, {'path': os.getcwd()}),
+        # (r"/static/(.*)", tornado.web.StaticFileHandler, {'path': path.join(here_path, "static")}),
+        # (r"/ajax", AjaxHandler, {"experiments_folder": os.getcwd()})],
+
         (r"/", MainHandler, main_handler_params),
         (r'/(favicon.ico)', tornado.web.StaticFileHandler, {"path": path.join(here_path, "static/")}),
-        (r"/file/(.*)", NoCacheStaticHandler, {'path': os.getcwd()}),
+        (r"/file/(.*)", NoCacheStaticHandler, {'path': MainHandler.experiments_folder}),
         (r"/static/(.*)", tornado.web.StaticFileHandler, {'path': path.join(here_path, "static")}),
-        (r"/ajax", AjaxHandler, {"experiments_folder": os.getcwd()})],
+        (r"/ajax", AjaxHandler)],
+
         {"debug": True}
     )
 
@@ -196,12 +212,14 @@ class MainHandler(tornado.web.RequestHandler):
 
     def get(self):
         experiment_folder = self.get_argument("experiment", default="")
+        log.info("experiment folder {}".format(self.experiments_folder))
         experiment_path = path.join(self.experiments_folder, experiment_folder)
 
         if not path.isdir(experiment_path):
             experiment_folder = ""
 
-        navigation_html = html_navigation(self.experiments_folder, experiment_folder)
+        navigation_html = html_navigation(self.experiments_folder,
+                                          experiment_folder)
         header_html = ""
         scripts_html = ""
 
@@ -215,14 +233,17 @@ class MainHandler(tornado.web.RequestHandler):
             # Use custom chain, if present
             if os.path.exists(experiment_path + "/custom_flexp_chain.py"):
                 try:
-                    custom_flexp_chain = import_by_filename('custom_flexp_chain',
-                                                            experiment_path + "/custom_flexp_chain.py")
+                    custom_flexp_chain = import_by_filename(
+                        'custom_flexp_chain',
+                        experiment_path + "/custom_flexp_chain.py")
                     html_chain = custom_flexp_chain.get_chain()
                     html_chain = Chain(html_chain)
                 except:
-                    html_chain = Chain([StringToHtml("<h2>Error processing custom chain. {}</h2>"
-                                                     .format(traceback.format_exc().replace("\n", "</br>")),
-                                                     title="Error in custom chain")] + self.html_chain.modules)
+                    html_chain = Chain([StringToHtml(
+                        "<h2>Error processing custom chain. {}</h2>"
+                            .format(
+                            traceback.format_exc().replace("\n", "</br>")),
+                        title="Error in custom chain")] + self.html_chain.modules)
                 finally:
                     if "custom_flexp_chain" in sys.modules:
                         del sys.modules["custom_flexp_chain"]
@@ -235,7 +256,8 @@ class MainHandler(tornado.web.RequestHandler):
             title_html = "<h1>{}</h1>".format(experiment_folder)
             content_html = u"\n".join(data['html'])
             navigation_html = html_anchor_navigation(
-                experiment_path, experiment_folder, html_chain) + navigation_html
+                experiment_path, experiment_folder,
+                html_chain) + navigation_html
 
             header_html = u"\n".join(u"\n".join(html_lines)
                                      for head_section, html_lines
@@ -282,15 +304,18 @@ class AjaxHandler(tornado.web.RequestHandler):
             new_name = self.get_argument('new_name')
             folder = os.path.join(self.experiments_folder, value)
             new_folder = os.path.join(self.experiments_folder, new_name)
-            if os.path.exists(folder) and not os.path.exists(new_folder) and "/" not in value and "/" not in new_name:
+            if os.path.exists(folder) and not os.path.exists(
+                    new_folder) and "/" not in value and "/" not in new_name:
                 os.rename(folder, new_folder)
             else:
-                self.send_error(500, reason="Rename folder not successful. Check old and new name.")
+                self.send_error(500,
+                                reason="Rename folder not successful. Check old and new name.")
 
         if action == "change_file_content":
             new_content = self.get_argument('new_content')
             file_name = self.get_argument('file_name')
-            with open(os.path.join(self.experiments_folder, value, file_name), "w") as file:
+            with open(os.path.join(self.experiments_folder, value, file_name),
+                      "w") as file:
                 file.write(new_content)
 
 
@@ -311,6 +336,7 @@ def html_table(base_dir, get_metrics_fcn, metrics_file):
                     {metrics_names}
                 </tr>
             </thead>
+<<<<<<< HEAD
             <tbody>
                 {rows}
             </tbody>
@@ -409,7 +435,8 @@ def html_navigation(base_dir, selected_experiment=None):
             <a class=\"{classes} left-margin\" href=\"?experiment={exp_dir}\" title=\"{title}\" style='padding-left:2px'>{exp_dir}</a>
             </div>""".format(
                 exp_dir=exp_dir,
-                title=DescriptionToHtml.get_description_html(exp_path, replace_newlines=False),
+                title=DescriptionToHtml.get_description_html(exp_path,
+                                                             replace_newlines=False),
                 classes=" ".join(classes)))
     return header + "\n".join(items)
 
@@ -440,15 +467,19 @@ def html_anchor_navigation(base_dir, experiment_dir, modules):
 
 
 def list_experiments(base_dir):
-    """Return list of tuples(experiment_directory, experiment_absolute_path).
+    """Return list of tuples(experiment_directory, experiment_absolute_path,
+    last modified time) sorted by modification time.
 
     :param base_dir: parent folder in which to look for an experiment folders
-    :return: list[tuple[str, str]]
+    :return: list[tuple[str, str, int]]
     """
-    return sorted([(exp_dir, path.join(base_dir, exp_dir), os.path.getmtime(exp_dir))
-                   for exp_dir in os.listdir(base_dir)
-                   if path.isdir(path.join(base_dir, exp_dir))],
-                  key=lambda x: x[2], reverse=True)
+    return sorted([
+        (exp_dir,
+         path.join(base_dir, exp_dir),
+         os.path.getmtime(path.join(base_dir, exp_dir)))
+        for exp_dir in os.listdir(base_dir)
+        if path.isdir(path.join(base_dir, exp_dir))],
+        key=lambda x: x[2], reverse=True)
 
 
 def return_type_list_of_dicts(fcn, return_on_fail=None):
@@ -474,12 +505,16 @@ class NoCacheStaticHandler(tornado.web.StaticFileHandler):
         return False
 
 
-@click.command()
-@click.option('--port', '-p', default=7777, help='Port where to run flexp browser')
-def main(port):
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option('--port', '-p', default=7777,
+              help='Port where to run flexp browser')
+@click.option('--experiments_dir', '-d', default=os.getcwd(),
+              help='path to directory with experiments')
+def main(port, experiments_dir):
     """Console entry point launched by flexp-browser command."""
     setup_logging("info")
-    run(port)
+    run(port=port,
+        experiments_dir=experiments_dir)
 
 
 if __name__ == "__main__":

--- a/flexp/browser/html/generic.py
+++ b/flexp/browser/html/generic.py
@@ -46,7 +46,7 @@ class TxtToHtml(ToHtml):
                "<b>{file_link}</b> " \
                "<div class=\"edit padding-right {class_editable}\" " \
                "onclick=\"$('#new_content').text('{content_strip}'); " \
-               "$('#edit-txt').data('folder', '{experiment_path}').data('file_name', '{filename}').dialog('open')\">&nbsp;" \
+               "$('#edit-txt').data('folder', '{experiment_folder}').data('file_name', '{filename}').dialog('open')\">&nbsp;" \
                "</div>" \
                "</div>" \
                "<p>{content}</p>" \
@@ -54,7 +54,7 @@ class TxtToHtml(ToHtml):
                "</div>"
 
     def to_html(self, file_name):
-        filepath = join(self.experiment_folder, file_name)
+        filepath = join(self.experiment_path, file_name)
         with io.open(filepath, encoding="utf8") as f:
             lines = list(islice(f, self.max_rows + 1))
             trimmed = len(lines) > self.max_rows
@@ -83,6 +83,7 @@ class TxtToHtml(ToHtml):
             file_link=link,
             content_strip=raw_content,
             experiment_path=self.experiment_path,
+            experiment_folder=self.experiment_folder,
             class_editable=class_editable,
             trim_msg=trim_msg,
         )

--- a/flexp/browser/static/script.js
+++ b/flexp/browser/static/script.js
@@ -121,9 +121,6 @@ function edit_txt(){
         $.post("/ajax", {action: "change_file_content", value: folder, file_name:file_name, new_content:new_content})
             .done(function(){
                 var url = location.href;
-                if (url.endsWith(folder)){
-                    url = url.replace(folder, new_name);
-                }
                 location.href = url;
             })
             .fail(function(xhr, status, error){


### PR DESCRIPTION
I used @tivvit branch, merged with current master and fixed some bugs: show txt file, rename/delete experiment, change content of text file

I created new branch due to not being able to push to original branch `browser-experiment-dir`

closes #14 