### PR TITLE
Fixing depracation warning: time.clock(); collections.Iterable

### DIFF
--- a/flexp/flow/cache.py
+++ b/flexp/flow/cache.py
@@ -237,7 +237,7 @@ class PickleCache(Chain, ObjectDumper):
         """
         chain_mtimes = [0.]  # default time in case no other time is obtained
         for module in chain:
-            if isinstance(module, collections.Iterable):  # module is a chain
+            if isinstance(module, collections.abc.Iterable):  # module is a chain
                 chain_mtimes.append(self._get_chain_mtime(module))
             elif hasattr(module, 'process'):  # module is an object
                 chain_mtimes.append(self._get_object_mtime(module))
@@ -254,7 +254,7 @@ class PickleCache(Chain, ObjectDumper):
         """
         chain_repr = []
         for module in chain:
-            if isinstance(module, collections.Iterable):  # module is a chain
+            if isinstance(module, collections.abc.Iterable):  # module is a chain
                 chain_repr.append(self._get_chain_repr(module))
             elif hasattr(module, 'process'):  # module is an object
                 chain_repr.extend(

--- a/flexp/flow/caching_chain.py
+++ b/flexp/flow/caching_chain.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 import hashlib
 import os
-import time
+import timeit
 
 from flexp.flow import Chain
 from flexp.flow.cache import PickleCache, ObjectDumper
@@ -109,11 +109,11 @@ class CachingChain(Chain, ObjectDumper):
                 else:
                     log.debug("{}()".format(self.names[i]))
                     process_func = self.modules[i]
-                start = time.clock()
+                start = timeit.default_timer()
                 # update data ket from list before running module
                 setattr(data, self.update_data_id,  updated_ids[i])
                 process_func(data)
-                end = time.clock()
+                end = timeit.default_timer()
                 self.times[i] += (end - start)
             except StopIteration:
                 log.debug("{} requested stop. Processing stopped".format(

--- a/flexp/flow/flow.py
+++ b/flexp/flow/flow.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import collections
-import time
+import timeit
 import types
 
 from flexp.utils import get_logger
@@ -67,7 +67,7 @@ class Chain(object):
         """
         if not module:
             return
-        if isinstance(module, collections.Iterable):
+        if isinstance(module, collections.abc.Iterable):
             for m in module:
                 self._add(m)
         else:
@@ -120,9 +120,9 @@ class Chain(object):
                 else:
                     log.debug("{}()".format(self.names[i]))
                     process_func = self.modules[i]
-                start = time.clock()
+                start = timeit.default_timer()
                 process_func(data)
-                end = time.clock()
+                end = timeit.default_timer()
                 self.times[i] += (end - start)
             except StopIteration:
                 log.debug("{} requested stop. Processing stopped".format(

--- a/tests/test_cache_attrs.py
+++ b/tests/test_cache_attrs.py
@@ -7,7 +7,7 @@ import unittest
 from flexp.flow import cache
 
 
-class TestModule:
+class DummyModule:
 
     PickleCacheBlackList = ['attr3']
 
@@ -37,20 +37,20 @@ class TestCache(unittest.TestCase):
     def test_cache(self):
 
         c = cache.PickleCache(self.cache_dir, "input", chain=[
-            TestModule(12, 14, 18),
+            DummyModule(12, 14, 18),
         ])
         c.process({"input": 10})
 
         # different value for attribute from black list
         c2 = cache.PickleCache(self.cache_dir, "input", chain=[
-            TestModule(12, 14, 20),
+            DummyModule(12, 14, 20),
         ])
         c2.process({"input": 10})
         self.assertEqual(c.chain_info['chain_hash'], c2.chain_info['chain_hash'])
 
         # different value for attribute that is not in black list
         c3 = cache.PickleCache(self.cache_dir, "input", chain=[
-            TestModule(12, 12, 18),
+            DummyModule(12, 12, 18),
         ])
         c3.process({"input": 10})
         self.assertFalse(c.chain_info['chain_hash'] == c3.chain_info['chain_hash'])

--- a/tests/test_flexp.py
+++ b/tests/test_flexp.py
@@ -3,10 +3,8 @@
 import atexit
 import io
 import os
-import time
 from os import path
 import shutil
-from pprint import pprint
 
 import pytest
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-import time
+import timeit
 import unittest
+
 
 from flexp.flow.parallel import parallelize
 
@@ -16,9 +17,11 @@ class TestParallel(unittest.TestCase):
         count = 50
         data = range(0, count)
 
-        start = time.clock()
+        start = timeit.default_timer()
         res = list(parallelize(add_two, data, 25))
-        end = time.clock()
+        end = timeit.default_timer()
+
         print("Time to process {}".format(end - start))
+
         assert len(res) == count
         assert sum(res) == (2 + count + 1) * count / 2


### PR DESCRIPTION
Changed `if isinstance(module, collections.Iterable)` to `if isinstance(module, collections.abc.Iterable)`. From doc `abc` was added in python 3.3, so it might not work on earlier versions. Is it problem for somebody?

Changed `time.clock()` to `timeit.default_timer()`

closes #27 